### PR TITLE
Remove duplicate get all prices

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -490,13 +490,14 @@ type AllRateEntry struct {
 }
 
 type AllRateResponse struct {
-	Version     Version
-	Valid       bool
-	Error       string
-	Timestamp   Timestamp
-	ReturnTime  Timestamp
-	Data        map[string]RateResponse
-	BlockNumber uint64
+	Version       Version
+	Valid         bool
+	Error         string
+	Timestamp     Timestamp
+	ReturnTime    Timestamp
+	Data          map[string]RateResponse
+	BlockNumber   uint64
+	ToBlockNumber uint64
 }
 
 type TradeLog struct {

--- a/data/reserve_data.go
+++ b/data/reserve_data.go
@@ -85,29 +85,29 @@ func (self ReserveData) CurrentRateVersion(timepoint uint64) (common.Version, er
 	return self.storage.CurrentRateVersion(timepoint)
 }
 
-func compareData(old, new map[string]common.RateResponse) bool {
-	for tokenID, oldElem := range old {
-		newelem, ok := new[tokenID]
+func isDuplicated(oldData, newData map[string]common.RateResponse) bool {
+	for tokenID, oldElem := range oldData {
+		newelem, ok := newData[tokenID]
 		if !ok {
-			return (false)
+			return false
 		}
 		if oldElem.BaseBuy != newelem.BaseBuy {
-			return (false)
+			return false
 		}
 		if oldElem.CompactBuy != newelem.CompactBuy {
-			return (false)
+			return false
 		}
 		if oldElem.BaseSell != newelem.BaseSell {
-			return (false)
+			return false
 		}
 		if oldElem.CompactSell != newelem.CompactSell {
-			return (false)
+			return false
 		}
 		if oldElem.Rate != newelem.Rate {
-			return (false)
+			return false
 		}
 	}
-	return (true)
+	return true
 }
 
 func getOneRateData(rate common.AllRateEntry) map[string]common.RateResponse {
@@ -145,10 +145,9 @@ func (self ReserveData) GetRates(fromTime, toTime uint64) ([]common.AllRateRespo
 		one.Valid = rate.Valid
 		one.Data = getOneRateData(rate)
 		one.BlockNumber = rate.BlockNumber
-		//if one is the same as current unchanged block
-		if compareData(one.Data, current.Data) {
+		//if one is the same as current
+		if isDuplicated(one.Data, current.Data) {
 			result[len(result)-1].ToBlockNumber = one.BlockNumber
-
 		} else {
 			one.ToBlockNumber = rate.BlockNumber
 			result = append(result, one)

--- a/data/reserve_data.go
+++ b/data/reserve_data.go
@@ -1,8 +1,6 @@
 package data
 
 import (
-	"log"
-
 	"github.com/KyberNetwork/reserve-data/common"
 )
 
@@ -94,11 +92,9 @@ func compareData(old, new map[string]common.RateResponse) bool {
 			return (false)
 		}
 		if oldElem.BaseBuy != newelem.BaseBuy {
-			log.Println("basebuy was different")
 			return (false)
 		}
 		if oldElem.CompactBuy != newelem.CompactBuy {
-			log.Println("compactBuy was different")
 			return (false)
 		}
 		if oldElem.BaseSell != newelem.BaseSell {
@@ -115,6 +111,7 @@ func compareData(old, new map[string]common.RateResponse) bool {
 }
 
 func getOneRateData(rate common.AllRateEntry) map[string]common.RateResponse {
+	//get data from rate object and return the data.
 	data := map[string]common.RateResponse{}
 	for tokenID, r := range rate.Data {
 		data[tokenID] = common.RateResponse{
@@ -148,6 +145,7 @@ func (self ReserveData) GetRates(fromTime, toTime uint64) ([]common.AllRateRespo
 		one.Valid = rate.Valid
 		one.Data = getOneRateData(rate)
 		one.BlockNumber = rate.BlockNumber
+		//if one is the same as current unchanged block
 		if compareData(one.Data, current.Data) {
 			result[len(result)-1].ToBlockNumber = one.BlockNumber
 
@@ -156,8 +154,6 @@ func (self ReserveData) GetRates(fromTime, toTime uint64) ([]common.AllRateRespo
 			result = append(result, one)
 			current = one
 		}
-		log.Println("from %d to %d", one.BlockNumber, one.ToBlockNumber)
-
 	}
 
 	return result, nil

--- a/data/reserve_data.go
+++ b/data/reserve_data.go
@@ -147,7 +147,11 @@ func (self ReserveData) GetRates(fromTime, toTime uint64) ([]common.AllRateRespo
 		one.BlockNumber = rate.BlockNumber
 		//if one is the same as current
 		if isDuplicated(one.Data, current.Data) {
-			result[len(result)-1].ToBlockNumber = one.BlockNumber
+			if len(result) > 0 {
+				result[len(result)-1].ToBlockNumber = one.BlockNumber
+			} else {
+				one.ToBlockNumber = one.BlockNumber
+			}
 		} else {
 			one.ToBlockNumber = rate.BlockNumber
 			result = append(result, one)

--- a/data/storage/bolt.go
+++ b/data/storage/bolt.go
@@ -232,8 +232,8 @@ func (self *BoltStorage) CurrentRateVersion(timepoint uint64) (common.Version, e
 
 func (self *BoltStorage) GetRates(fromTime, toTime uint64) ([]common.AllRateEntry, error) {
 	result := []common.AllRateEntry{}
-	if toTime-fromTime > 3600000 {
-		return result, errors.New("Time range is too broad, it must be smaller or equal to 3600000 miliseconds")
+	if toTime-fromTime > 86400000 {
+		return result, errors.New("Time range is too broad, it must be smaller or equal to 86400000 miliseconds")
 	}
 	var err error
 	self.db.View(func(tx *bolt.Tx) error {

--- a/data/storage/bolt.go
+++ b/data/storage/bolt.go
@@ -30,6 +30,7 @@ const (
 	TRADE_HISTORY           string = "trade_history"
 	ENABLE_REBALANCE        string = "enable_rebalance"
 	MAX_NUMBER_VERSION      int    = 1000
+	MAX_GET_RATES_PERIOD    uint64 = 86400000 //1 days in milisec
 )
 
 type BoltStorage struct {
@@ -232,8 +233,8 @@ func (self *BoltStorage) CurrentRateVersion(timepoint uint64) (common.Version, e
 
 func (self *BoltStorage) GetRates(fromTime, toTime uint64) ([]common.AllRateEntry, error) {
 	result := []common.AllRateEntry{}
-	if toTime-fromTime > 86400000 {
-		return result, errors.New("Time range is too broad, it must be smaller or equal to 86400000 miliseconds")
+	if toTime-fromTime > MAX_GET_RATES_PERIOD {
+		return result, errors.New(fmt.Sprintf("Time range is too broad, it must be smaller or equal to %d miliseconds", MAX_GET_RATES_PERIOD))
 	}
 	var err error
 	self.db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
Reduced the amount of data return on get all rates by grouping them from Block X to Block Y, provided the following condition:

- Every block between X and Y contains all the same Crypto ID
- With each Crypto ID, the BaseBuy, CompactBuy, BaseSell, CompactSell, Rate are the same for everyt block between X and Y.

Increased the Get_all_rates period form 1 hour to 24 hours.
Clean the code and increase its readability. 