### PR TITLE
Compare set rate get rate

### DIFF
--- a/cmd/comparerates/getrespond.go
+++ b/cmd/comparerates/getrespond.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/KyberNetwork/reserve-data/common"
+	ihttp "github.com/KyberNetwork/reserve-data/http"
+	"github.com/KyberNetwork/reserve-data/signer"
+)
+
+func SortByKey(params map[string]string) map[string]string {
+	newParams := make(map[string]string, len(params))
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		newParams[key] = params[key]
+	}
+	return newParams
+}
+
+func MakeSign(req *http.Request, message string, nonce string) {
+
+	//fmt.Println(message)
+	fileSigner, _ := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_config.json")
+
+	hmac512auth := ihttp.KNAuthentication{
+		fileSigner.KNSecret,
+		REQ_SESCRET,
+		fileSigner.KNConfiguration,
+		fileSigner.KNConfirmConf,
+	}
+	signed := hmac512auth.KNReadonlySign(message)
+	req.Header.Add("nonce", nonce)
+	req.Header.Add("signed", signed)
+}
+
+func GetResponse(method string, url string,
+	params map[string]string, signNeeded bool, timepoint uint64) ([]byte, error) {
+	params = SortByKey(params)
+	client := &http.Client{
+		Timeout: time.Duration(30 * time.Second),
+	}
+	//create request
+	req, ok := http.NewRequest(method, url, nil)
+	if ok != nil {
+		fmt.Println("can't establish request", ok)
+	}
+	// Add header
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	// Create raw query
+	q := req.URL.Query()
+	for k, v := range params {
+		q.Add(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+	if signNeeded {
+		nonce, ok := params["nonce"]
+		if !ok {
+			log.Printf("there was no nonce")
+		} else {
+			MakeSign(req, q.Encode(), nonce)
+		}
+	}
+	//do the request and return the reply
+	var err error
+	var resp_body []byte
+	resp, err := client.Do(req)
+	if err != nil {
+		return resp_body, err
+	} else {
+		defer resp.Body.Close()
+		switch resp.StatusCode {
+		case 429:
+			err = errors.New("breaking a request rate limit.")
+		case 418:
+			err = errors.New("IP has been auto-banned for continuing to send requests after receiving 429 codes.")
+		case 500:
+			err = errors.New("500 from Binance, its fault.")
+		case 200:
+			resp_body, err = ioutil.ReadAll(resp.Body)
+		}
+		log.Printf("\n request to %s, got response: \n %s \n\n", req.URL, common.TruncStr(resp_body))
+		return resp_body, err
+	}
+}

--- a/cmd/comparerates/getrespond.go
+++ b/cmd/comparerates/getrespond.go
@@ -8,9 +8,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/KyberNetwork/reserve-data/cmd/configuration"
 	"github.com/KyberNetwork/reserve-data/common"
-	ihttp "github.com/KyberNetwork/reserve-data/http"
-	"github.com/KyberNetwork/reserve-data/signer"
 )
 
 func SortByKey(params map[string]string) map[string]string {
@@ -26,9 +25,9 @@ func SortByKey(params map[string]string) map[string]string {
 	return newParams
 }
 
-func MakeSign(req *http.Request, message string, nonce string) {
+func MakeSign(req *http.Request, message string, nonce string, config configuration.Config) {
 
-	//fmt.Println(message)
+	/*fmt.Println(message)
 	fileSigner, _ := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_config.json")
 
 	hmac512auth := ihttp.KNAuthentication{
@@ -37,13 +36,15 @@ func MakeSign(req *http.Request, message string, nonce string) {
 		fileSigner.KNConfiguration,
 		fileSigner.KNConfirmConf,
 	}
-	signed := hmac512auth.KNReadonlySign(message)
+	hmac512auth.KNReadonlySign(message) */
+	signed := config.AuthEngine.KNSign(message)
+
 	req.Header.Add("nonce", nonce)
 	req.Header.Add("signed", signed)
 }
 
 func GetResponse(method string, url string,
-	params map[string]string, signNeeded bool, timepoint uint64) ([]byte, error) {
+	params map[string]string, signNeeded bool, timepoint uint64, config configuration.Config) ([]byte, error) {
 	params = SortByKey(params)
 	client := &http.Client{
 		Timeout: time.Duration(30 * time.Second),
@@ -67,7 +68,7 @@ func GetResponse(method string, url string,
 		if !ok {
 			log.Printf("there was no nonce")
 		} else {
-			MakeSign(req, q.Encode(), nonce)
+			MakeSign(req, q.Encode(), nonce, config)
 		}
 	}
 	//do the request and return the reply

--- a/cmd/comparerates/getrespond.go
+++ b/cmd/comparerates/getrespond.go
@@ -26,17 +26,9 @@ func SortByKey(params map[string]string) map[string]string {
 }
 
 func MakeSign(req *http.Request, message string, nonce string, config configuration.Config) {
-
-	/*fmt.Println(message)
-	fileSigner, _ := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_config.json")
-
-	hmac512auth := ihttp.KNAuthentication{
-		fileSigner.KNSecret,
-		REQ_SESCRET,
-		fileSigner.KNConfiguration,
-		fileSigner.KNConfirmConf,
+	if config.AuthEngine == nil {
+		log.Fatal("the environment doesn't come with AuthEngine object, try stagging env ")
 	}
-	hmac512auth.KNReadonlySign(message) */
 	signed := config.AuthEngine.KNSign(message)
 
 	req.Header.Add("nonce", nonce)
@@ -73,20 +65,20 @@ func GetResponse(method string, url string,
 	}
 	//do the request and return the reply
 	var err error
-	var resp_body []byte
+	var resbody []byte
 	resp, err := client.Do(req)
 	if err != nil {
-		return resp_body, err
+		return resbody, err
 	} else {
 		defer resp.Body.Close()
 		switch resp.StatusCode {
 		case 200:
-			resp_body, err = ioutil.ReadAll(resp.Body)
+			resbody, err = ioutil.ReadAll(resp.Body)
 		default:
 			log.Printf("The reply code %v was unexpected", resp.StatusCode)
-			resp_body, err = ioutil.ReadAll(resp.Body)
+			resbody, err = ioutil.ReadAll(resp.Body)
 		}
-		log.Printf("\n request to %s, got response: \n %s \n\n", req.URL, common.TruncStr(resp_body))
-		return resp_body, err
+		log.Printf("\n request to %s, got response: \n %s \n\n", req.URL, common.TruncStr(resbody))
+		return resbody, err
 	}
 }

--- a/cmd/comparerates/getrespond.go
+++ b/cmd/comparerates/getrespond.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -80,13 +79,10 @@ func GetResponse(method string, url string,
 	} else {
 		defer resp.Body.Close()
 		switch resp.StatusCode {
-		case 429:
-			err = errors.New("breaking a request rate limit.")
-		case 418:
-			err = errors.New("IP has been auto-banned for continuing to send requests after receiving 429 codes.")
-		case 500:
-			err = errors.New("500 from Binance, its fault.")
 		case 200:
+			resp_body, err = ioutil.ReadAll(resp.Body)
+		default:
+			log.Printf("The reply code %v was unexpected", resp.StatusCode)
 			resp_body, err = ioutil.ReadAll(resp.Body)
 		}
 		log.Printf("\n request to %s, got response: \n %s \n\n", req.URL, common.TruncStr(resp_body))

--- a/cmd/comparerates/main.go
+++ b/cmd/comparerates/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/KyberNetwork/reserve-data/common"
+	ihttp "github.com/KyberNetwork/reserve-data/http"
+	"github.com/KyberNetwork/reserve-data/signer"
+)
+
+const (
+	BASE_URL    string = "https://internal-mainnet-core.kyber.network"
+	REQ_SESCRET string = "vtHpz1l0kxLyGc4R1qJBkFlQre5352xGJU9h8UQTwUTz5p6VrxcEslF4KnDI21s1"
+	CONFIG_PATH string = "/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_config.json"
+)
+
+type AllRateHTTPReply struct {
+	Data    []common.AllRateResponse
+	Success bool
+}
+
+type AllActionHTTPReply struct {
+	Data    []common.ActivityRecord
+	Success bool
+}
+
+func SortByKey(params map[string]string) map[string]string {
+	//to be implement
+	newParams := make(map[string]string, len(params))
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		newParams[key] = params[key]
+	}
+	return newParams
+}
+
+func MakeSign(req *http.Request, message string, nonce string) {
+
+	fmt.Println(message)
+	//fmt.Println(message)
+	fileSigner, _ := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_config.json")
+
+	hmac512auth := ihttp.KNAuthentication{
+		fileSigner.KNSecret,
+		REQ_SESCRET,
+		fileSigner.KNConfiguration,
+		fileSigner.KNConfirmConf,
+	}
+	signed := hmac512auth.KNReadonlySign(message)
+	req.Header.Add("nonce", nonce)
+	req.Header.Add("signed", signed)
+}
+
+func GetResponse(method string, url string,
+	params map[string]string, signNeeded bool, timepoint uint64) ([]byte, error) {
+	params = SortByKey(params)
+	client := &http.Client{
+		Timeout: time.Duration(30 * time.Second),
+	}
+	//create request
+	req, ok := http.NewRequest(method, url, nil)
+	if ok != nil {
+		fmt.Println("can't establish request", ok)
+	}
+	// Add header
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	// Create raw query
+	q := req.URL.Query()
+	for k, v := range params {
+		q.Add(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+	if signNeeded {
+		nonce, ok := params["nonce"]
+		if !ok {
+			log.Fatal("there was no nonce")
+		} else {
+			MakeSign(req, q.Encode(), nonce)
+		}
+	}
+	//do the request and return the reply
+	var err error
+	var resp_body []byte
+	resp, err := client.Do(req)
+	if err != nil {
+		return resp_body, err
+	} else {
+		defer resp.Body.Close()
+		switch resp.StatusCode {
+		case 429:
+			err = errors.New("breaking a request rate limit.")
+		case 418:
+			err = errors.New("IP has been auto-banned for continuing to send requests after receiving 429 codes.")
+		case 500:
+			err = errors.New("500 from Binance, its fault.")
+		case 200:
+			resp_body, err = ioutil.ReadAll(resp.Body)
+		}
+		log.Printf("\n request to %s, got response: \n %s \n\n", req.URL, common.TruncStr(resp_body))
+		return resp_body, err
+	}
+}
+
+func GetActivitiesResponse(params map[string]string) (AllActionHTTPReply, error) {
+	timepoint := (time.Now().UnixNano() / int64(time.Millisecond))
+	nonce := strconv.FormatInt(timepoint, 10)
+	var allActionRep AllActionHTTPReply
+	params["nonce"] = nonce
+	data, err := GetResponse("GET", fmt.Sprintf("%s/%s", BASE_URL, "activities"), params, true, uint64(timepoint))
+
+	if err != nil {
+		fmt.Println("can't get response", err)
+	} else {
+		if err := json.Unmarshal(data, &allActionRep); err != nil {
+			fmt.Println("can't decode the reply", err)
+			return allActionRep, err
+		}
+	}
+	return allActionRep, nil
+}
+
+func GetAllRateResponse(params map[string]string) (AllRateHTTPReply, error) {
+	timepoint := (time.Now().UnixNano() / int64(time.Millisecond))
+	var allRateRep AllRateHTTPReply
+	data, err := GetResponse("GET", fmt.Sprintf("%s/%s", BASE_URL, "get-all-rates"), params, false, uint64(timepoint))
+
+	if err != nil {
+		fmt.Println("can't get response", err)
+	} else {
+		if err := json.Unmarshal(data, &allRateRep); err != nil {
+			fmt.Println("can't decode the reply", err)
+			return allRateRep, err
+		}
+	}
+	return allRateRep, nil
+}
+
+func RateDifference(r1, r2 float64) float64 {
+	return (math.Abs(r1-r2) / r1)
+}
+
+func Compare(oneAct common.ActivityRecord, oneRate common.AllRateResponse, blockID uint64) {
+	tokenIDs, asrt := oneAct.Params["tokens"].([]interface{})
+	buys, asrt1 := oneAct.Params["buys"].([]interface{})
+	sells, asrt2 := oneAct.Params["sells"].([]interface{})
+	if asrt && asrt1 && asrt2 {
+		for idx, tokenID := range tokenIDs {
+			tokenid, _ := tokenID.(string)
+			val, ok := oneRate.Data[tokenid]
+			if ok {
+				differ := RateDifference(val.BaseBuy, buys[idx].(float64)/1000000000000000000)
+				if differ > 0.001 {
+					fmt.Printf("block %d set a buy rate differ %.5f than get rate at token %s \n", blockID, differ, tokenid)
+				}
+				differ = RateDifference(val.BaseSell, sells[idx].(float64)/1000000000000000000)
+				if differ > 0.001 {
+					fmt.Printf("block %d set a sell rate differ %.5f than get rate at token %s \n", blockID, differ, tokenid)
+				}
+			}
+		}
+	}
+}
+
+func CompareRate(acts []common.ActivityRecord, rates []common.AllRateResponse) {
+	idx := 0
+	for _, oneAct := range acts {
+		if oneAct.Action == "set_rates" {
+			_, ok := oneAct.Params["block"]
+			if ok {
+				curBlock := uint64(oneAct.Params["block"].(float64))
+				for (curBlock < rates[idx].ToBlockNumber) && (idx < len(rates)) {
+					idx += 1
+				}
+				if (curBlock <= rates[idx].BlockNumber) && (curBlock >= rates[idx].ToBlockNumber) {
+					fmt.Printf("\n Block %d is found between block %d to block %d \n", curBlock, rates[idx].BlockNumber, rates[idx].ToBlockNumber)
+					Compare(oneAct, rates[idx], curBlock)
+				} else {
+					fmt.Printf("\n Block %d is not found\n", curBlock)
+				}
+			}
+		}
+	}
+}
+
+func main() {
+
+	params := make(map[string]string)
+	params["fromTime"] = "1518240610536"
+	params["toTime"] = "1518247610536"
+	allActionRep, err := GetActivitiesResponse(params)
+	if err != nil {
+		log.Fatal("couldn't get activites: ", err)
+	}
+	allRateRep, err := GetAllRateResponse(params)
+	if err != nil {
+		log.Fatal("couldn't get all rates: ", err)
+	}
+	CompareRate(allActionRep.Data, allRateRep.Data)
+}

--- a/cmd/comparerates/main.go
+++ b/cmd/comparerates/main.go
@@ -85,7 +85,6 @@ func printInterfaceMap(inf map[string]interface{}) {
 
 func printAction(oneAct common.ActivityRecord) {
 	i := int64(oneAct.Timestamp.ToUint64()) / 1000
-
 	log.Printf("\t Time: %v", time.Unix(i, 0))
 	log.Printf("\t Activity : %v\n", oneAct.Action)
 	log.Printf("\t Destination : %v\n", oneAct.Destination)
@@ -173,6 +172,7 @@ func main() {
 	if len(params["fromTime"]) < 1 {
 		log.Fatal("Wrong usage \n FROMTIME=<timestamp> [TOTIME=<totime>] ./compareRates")
 	}
+
 	if len(params["toTime"]) < 1 {
 		log.Printf("There was no end time, go to foverer run mode...")
 		for {

--- a/cmd/configuration/config.go
+++ b/cmd/configuration/config.go
@@ -1,4 +1,4 @@
-package main
+package configuration
 
 import (
 	"github.com/KyberNetwork/reserve-data/blockchain"

--- a/cmd/configuration/dev.go
+++ b/cmd/configuration/dev.go
@@ -1,4 +1,4 @@
-package main
+package configuration
 
 import (
 	"log"
@@ -7,12 +7,14 @@ import (
 	"github.com/KyberNetwork/reserve-data/common"
 	"github.com/KyberNetwork/reserve-data/data/fetcher"
 	"github.com/KyberNetwork/reserve-data/data/storage"
+	"github.com/KyberNetwork/reserve-data/http"
 	"github.com/KyberNetwork/reserve-data/signer"
 	ethereum "github.com/ethereum/go-ethereum/common"
 )
 
-func GetConfigForRopsten() *Config {
-	settingPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/ropsten_setting.json"
+func GetConfigForDev() *Config {
+	// settingPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/dev_setting.json"
+	settingPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/staging_setting.json"
 	addressConfig, err := common.GetAddressConfigFromFile(settingPath)
 	if err != nil {
 		log.Fatalf("Config file %s is not found. Error: %s", settingPath, err)
@@ -23,8 +25,8 @@ func GetConfigForRopsten() *Config {
 		log.Fatalf("Fees file cannot found at: %s", feePath, err)
 	}
 	wrapperAddr := ethereum.HexToAddress(addressConfig.Wrapper)
-	pricingAddr := ethereum.HexToAddress(addressConfig.Pricing)
 	reserveAddr := ethereum.HexToAddress(addressConfig.Reserve)
+	pricingAddr := ethereum.HexToAddress(addressConfig.Pricing)
 	burnerAddr := ethereum.HexToAddress(addressConfig.FeeBurner)
 	networkAddr := ethereum.HexToAddress(addressConfig.Network)
 
@@ -38,7 +40,7 @@ func GetConfigForRopsten() *Config {
 		tokens = append(tokens, tok)
 	}
 
-	storage, err := storage.NewBoltStorage("/go/src/github.com/KyberNetwork/reserve-data/cmd/ropsten.db")
+	storage, err := storage.NewBoltStorage("/go/src/github.com/KyberNetwork/reserve-data/cmd/dev.db")
 	if err != nil {
 		panic(err)
 	}
@@ -47,15 +49,23 @@ func GetConfigForRopsten() *Config {
 
 	fileSigner, depositSigner := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/config.json")
 
-	exchangePool := NewRopstenExchangePool(
+	exchangePool := NewDevExchangePool(
 		feeConfig, addressConfig, fileSigner, storage,
 	)
 
-	// endpoint := "http://localhost:8545"
-	// endpoint := "https://ropsten.kyber.network"
-	endpoint := "https://ropsten.infura.io"
+	// endpoint := "https://ropsten.infura.io"
+	// endpoint := "http://blockchain:8545"
+	// endpoint := "https://kovan.infura.io"
+	endpoint := "https://mainnet.infura.io"
 	bkendpoints := []string{
-		"https://api.myetherapi.com/rop",
+		"https://mainnet.infura.io",
+	}
+
+	hmac512auth := http.KNAuthentication{
+		fileSigner.KNSecret,
+		fileSigner.KNReadOnly,
+		fileSigner.KNConfiguration,
+		fileSigner.KNConfirmConf,
 	}
 
 	return &Config{
@@ -67,7 +77,9 @@ func GetConfigForRopsten() *Config {
 		FetcherExchanges:        exchangePool.FetcherExchanges(),
 		Exchanges:               exchangePool.CoreExchanges(),
 		BlockchainSigner:        fileSigner,
+		EnableAuthentication:    true,
 		DepositSigner:           depositSigner,
+		AuthEngine:              hmac512auth,
 		EthereumEndpoint:        endpoint,
 		BackupEthereumEndpoints: bkendpoints,
 		SupportedTokens:         tokens,

--- a/cmd/configuration/exchanges.go
+++ b/cmd/configuration/exchanges.go
@@ -1,4 +1,4 @@
-package main
+package configuration
 
 import (
 	"os"

--- a/cmd/configuration/kovan.go
+++ b/cmd/configuration/kovan.go
@@ -1,4 +1,4 @@
-package main
+package configuration
 
 import (
 	"log"
@@ -7,13 +7,12 @@ import (
 	"github.com/KyberNetwork/reserve-data/common"
 	"github.com/KyberNetwork/reserve-data/data/fetcher"
 	"github.com/KyberNetwork/reserve-data/data/storage"
-	"github.com/KyberNetwork/reserve-data/http"
 	"github.com/KyberNetwork/reserve-data/signer"
 	ethereum "github.com/ethereum/go-ethereum/common"
 )
 
-func GetConfigForMainnet() *Config {
-	settingPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/mainnet_setting.json"
+func GetConfigForKovan() *Config {
+	settingPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/kovan_setting.json"
 	addressConfig, err := common.GetAddressConfigFromFile(settingPath)
 	if err != nil {
 		log.Fatalf("Config file %s is not found. Error: %s", settingPath, err)
@@ -24,8 +23,8 @@ func GetConfigForMainnet() *Config {
 		log.Fatalf("Fees file cannot found at: %s", feePath, err)
 	}
 	wrapperAddr := ethereum.HexToAddress(addressConfig.Wrapper)
-	reserveAddr := ethereum.HexToAddress(addressConfig.Reserve)
 	pricingAddr := ethereum.HexToAddress(addressConfig.Pricing)
+	reserveAddr := ethereum.HexToAddress(addressConfig.Reserve)
 	burnerAddr := ethereum.HexToAddress(addressConfig.FeeBurner)
 	networkAddr := ethereum.HexToAddress(addressConfig.Network)
 
@@ -39,34 +38,22 @@ func GetConfigForMainnet() *Config {
 		tokens = append(tokens, tok)
 	}
 
-	storage, err := storage.NewBoltStorage("/go/src/github.com/KyberNetwork/reserve-data/cmd/mainnet.db")
+	storage, err := storage.NewBoltStorage("/go/src/github.com/KyberNetwork/reserve-data/cmd/kovan.db")
 	if err != nil {
 		panic(err)
 	}
 
 	fetcherRunner := fetcher.NewTickerRunner(3*time.Second, 2*time.Second, 3*time.Second, 5*time.Second, 5*time.Second)
 
-	fileSigner, depositSigner := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/mainnet_config.json")
+	fileSigner, depositSigner := signer.NewFileSigner("/go/src/github.com/KyberNetwork/reserve-data/cmd/config.json")
 
-	exchangePool := NewMainnetExchangePool(
+	exchangePool := NewKovanExchangePool(
 		feeConfig, addressConfig, fileSigner, storage,
 	)
 
-	hmac512auth := http.KNAuthentication{
-		fileSigner.KNSecret,
-		fileSigner.KNReadOnly,
-		fileSigner.KNConfiguration,
-		fileSigner.KNConfirmConf,
-	}
-
-	endpoint := "https://mainnet.infura.io"
-	bkendpoints := []string{
-		"https://node.kyber.network",
-		"https://mainnet.infura.io",
-		"https://api.mycryptoapi.com/eth",
-		"https://api.myetherapi.com/eth",
-		"https://mew.giveth.io/",
-	}
+	// endpoint := "http://localhost:8545"
+	endpoint := "https://kovan.infura.io"
+	bkendpoints := []string{}
 
 	return &Config{
 		ActivityStorage:         storage,
@@ -78,8 +65,6 @@ func GetConfigForMainnet() *Config {
 		Exchanges:               exchangePool.CoreExchanges(),
 		BlockchainSigner:        fileSigner,
 		DepositSigner:           depositSigner,
-		EnableAuthentication:    true,
-		AuthEngine:              hmac512auth,
 		EthereumEndpoint:        endpoint,
 		BackupEthereumEndpoints: bkendpoints,
 		SupportedTokens:         tokens,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/KyberNetwork/reserve-data/blockchain"
 	"github.com/KyberNetwork/reserve-data/blockchain/nonce"
+	"github.com/KyberNetwork/reserve-data/cmd/configuration"
 	"github.com/KyberNetwork/reserve-data/common"
 	"github.com/KyberNetwork/reserve-data/core"
 	"github.com/KyberNetwork/reserve-data/data"
@@ -37,34 +38,34 @@ func main() {
 	numCPU := runtime.NumCPU()
 	runtime.GOMAXPROCS(numCPU)
 
-	var config *Config
+	var config *configuration.Config
 	switch os.Getenv("KYBER_ENV") {
 	case "mainnet", "production":
 		log.Printf("Running in production mode")
-		config = GetConfigForMainnet()
+		config = configuration.GetConfigForMainnet()
 		break
 	case "staging":
 		log.Printf("Running in staging mode")
-		config = GetConfigForStaging()
+		config = configuration.GetConfigForStaging()
 		break
 	case "simulation":
 		log.Printf("Running in simulation mode")
-		config = GetConfigForSimulation()
+		config = configuration.GetConfigForSimulation()
 		break
 	case "kovan":
 		log.Printf("Running in kovan mode")
-		config = GetConfigForKovan()
+		config = configuration.GetConfigForKovan()
 		break
 	case "ropsten":
 		log.Printf("Running in ropsten mode")
-		config = GetConfigForRopsten()
+		config = configuration.GetConfigForRopsten()
 		break
 	case "dev":
 		log.Printf("Running in dev mode")
-		config = GetConfigForDev()
+		config = configuration.GetConfigForDev()
 	default:
 		log.Printf("Running in dev mode")
-		config = GetConfigForDev()
+		config = configuration.GetConfigForDev()
 	}
 
 	logPath := "/go/src/github.com/KyberNetwork/reserve-data/cmd/log.log"


### PR DESCRIPTION
Compare the rate between two API calls: **activites** and **get_all_rates**.

For each block with a blockID on a set_rate **activity**, compare its sell/ buy rate to the block with the same BlockID from **get_all_rates**. Print out every blockID with a difference more than 1%

The formula for comparison is:

```
activityRate = Activity.rate 
getAllRate = Get_all_rates.base*(1+Get_all_rates.compact/1000)
difference = (activityRate-getAllRate)/getAllRate

```
Compile :
`cd cmd/comparerates && go build -v`

Run:
`FROMTIME=<timestamp> [TOTIME=<totime>] ./compareRates
`
Notes: if both Params are available, the program will run one-off query. If only FROMTIME is available, the program will enter forever query mode, which query FROMTIME to current time and continue to query each period of 60 seconds. 