### PR TITLE
Use gometalinter for static check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,13 @@ go_import_path: github.com/KyberNetwork/reserve-data
 
 language: go
 
+install:
+  - go get -u github.com/alecthomas/gometalinter
+  - gometalinter --install
+
+script:
+  - gometalinter --config=gometalinter.json ./...
+  - go test -v ./...
+
 go:
   - "1.10.x"

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -358,11 +358,11 @@ func (self *Blockchain) FetchRates(atBlock uint64, currentBlock uint64) (common.
 		result.Data = map[string]common.RateEntry{}
 		for i, token := range validTokens {
 			result.Data[token.ID] = common.RateEntry{
-				baseBuys[i],
-				int8(compactBuys[i]),
-				baseSells[i],
-				int8(compactSells[i]),
-				blocks[i].Uint64(),
+				BaseBuy:     baseBuys[i],
+				CompactBuy:  int8(compactBuys[i]),
+				BaseSell:    baseSells[i],
+				CompactSell: int8(compactSells[i]),
+				Block:       blocks[i].Uint64(),
 			}
 		}
 		return result, nil
@@ -427,11 +427,11 @@ func (self *Blockchain) GetRawLogs(fromBlock uint64, toBlock uint64) ([]types.Lo
 	addresses = append(addresses, self.oldNetworks...)
 	addresses = append(addresses, self.oldBurners...)
 	param := ether.FilterQuery{
-		big.NewInt(int64(fromBlock)),
-		to,
-		addresses,
-		[][]ethereum.Hash{
-			[]ethereum.Hash{
+		FromBlock: big.NewInt(int64(fromBlock)),
+		ToBlock:   to,
+		Addresses: addresses,
+		Topics: [][]ethereum.Hash{
+			{
 				ethereum.HexToHash(TradeEvent),
 				ethereum.HexToHash(BurnFeeEvent),
 				ethereum.HexToHash(FeeToWalletEvent),

--- a/cmd/configuration/getconfig.go
+++ b/cmd/configuration/getconfig.go
@@ -85,7 +85,7 @@ func GetConfig(kyberENV string, authEnbl bool, endpointOW string, noCore, enable
 
 	for id, t := range addressConfig.Tokens {
 		tok := common.Token{
-			id, t.Address, t.Decimals,
+			ID: id, Address: t.Address, Decimal: t.Decimals,
 		}
 		if t.Active {
 			if t.KNReserveSupport {

--- a/core/reserve_core_test.go
+++ b/core/reserve_core_test.go
@@ -136,7 +136,7 @@ func TestNotAllowDeposit(t *testing.T) {
 	core := getTestCore(alreadyHasDepositForOMGOnBittrex)
 	_, err := core.Deposit(
 		testExchange{},
-		common.Token{"OMG", "0x1111111111111111111111111111111111111111", 18},
+		common.Token{ID: "OMG", Address: "0x1111111111111111111111111111111111111111", Decimal: 18},
 		big.NewInt(10),
 		common.GetTimepoint(),
 	)
@@ -145,7 +145,7 @@ func TestNotAllowDeposit(t *testing.T) {
 	}
 	_, err = core.Deposit(
 		testExchange{},
-		common.Token{"KNC", "0x1111111111111111111111111111111111111111", 18},
+		common.Token{ID: "KNC", Address: "0x1111111111111111111111111111111111111111", Decimal: 18},
 		big.NewInt(10),
 		common.GetTimepoint(),
 	)

--- a/data/fetcher/fetcher.go
+++ b/data/fetcher/fetcher.go
@@ -228,8 +228,8 @@ func (self *Fetcher) FetchTradeHistoryFromExchange(
 
 func (self *Fetcher) FetchAllTradeHistory(timepoint uint64) {
 	tradeHistory := common.AllTradeHistory{
-		common.GetTimestamp(),
-		map[common.ExchangeID]common.ExchangeTradeHistory{},
+		Timestamp: common.GetTimestamp(),
+		Data:      map[common.ExchangeID]common.ExchangeTradeHistory{},
 	}
 	wait := sync.WaitGroup{}
 	data := sync.Map{}
@@ -337,41 +337,41 @@ func (self *Fetcher) FetchStatusFromBlockchain(pendings []common.ActivityRecord)
 						nonce, _ := strconv.ParseUint(actNonce.(string), 10, 64)
 						if nonce < minedNonce {
 							result[activity.ID] = common.ActivityStatus{
-								activity.ExchangeStatus,
-								activity.Result["tx"].(string),
-								blockNum,
-								"failed",
-								err,
+								ExchangeStatus: activity.ExchangeStatus,
+								Tx:             activity.Result["tx"].(string),
+								BlockNumber:    blockNum,
+								MiningStatus:   "failed",
+								Error:          err,
 							}
 						}
 					}
 				}
 			case "mined":
 				result[activity.ID] = common.ActivityStatus{
-					activity.ExchangeStatus,
-					activity.Result["tx"].(string),
-					blockNum,
-					"mined",
-					err,
+					ExchangeStatus: activity.ExchangeStatus,
+					Tx:             activity.Result["tx"].(string),
+					BlockNumber:    blockNum,
+					MiningStatus:   "mined",
+					Error:          err,
 				}
 			case "failed":
 				result[activity.ID] = common.ActivityStatus{
-					activity.ExchangeStatus,
-					activity.Result["tx"].(string),
-					blockNum,
-					"failed",
-					err,
+					ExchangeStatus: activity.ExchangeStatus,
+					Tx:             activity.Result["tx"].(string),
+					BlockNumber:    blockNum,
+					MiningStatus:   "failed",
+					Error:          err,
 				}
 			case "lost":
 				elapsed := common.GetTimepoint() - activity.Timestamp.ToUint64()
 				if elapsed > uint64(15*time.Minute/time.Millisecond) {
 					log.Printf("Fetcher tx status: tx(%s) is lost, elapsed time: %d", activity.Result["tx"].(string), elapsed)
 					result[activity.ID] = common.ActivityStatus{
-						activity.ExchangeStatus,
-						activity.Result["tx"].(string),
-						blockNum,
-						"failed",
-						err,
+						ExchangeStatus: activity.ExchangeStatus,
+						Tx:             activity.Result["tx"].(string),
+						BlockNumber:    blockNum,
+						MiningStatus:   "failed",
+						Error:          err,
 					}
 				}
 			}
@@ -558,7 +558,7 @@ func (self *Fetcher) FetchStatusFromExchange(exchange Exchange, pendings []commo
 				continue
 			}
 			result[id] = common.ActivityStatus{
-				status, tx, blockNum, activity.MiningStatus, err,
+				ExchangeStatus: status, Tx: tx, BlockNumber: blockNum, MiningStatus: activity.MiningStatus, Error: err,
 			}
 		}
 	}

--- a/data/fetcher/fetcher_test.go
+++ b/data/fetcher/fetcher_test.go
@@ -18,16 +18,16 @@ import (
 func TestUnchangedFunc(t *testing.T) {
 	// test different len
 	a1 := map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 := map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
-		{2, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 2, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	if unchanged(a1, b1) != false {
@@ -35,13 +35,13 @@ func TestUnchangedFunc(t *testing.T) {
 	}
 	// test different id
 	a1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 = map[common.ActivityID]common.ActivityStatus{
-		{2, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 2, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	if unchanged(a1, b1) != false {
@@ -49,13 +49,13 @@ func TestUnchangedFunc(t *testing.T) {
 	}
 	// test different exchange status
 	a1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	if unchanged(a1, b1) != false {
@@ -63,13 +63,13 @@ func TestUnchangedFunc(t *testing.T) {
 	}
 	// test different mining status
 	a1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123",
 		},
 	}
 	if unchanged(a1, b1) != false {
@@ -77,13 +77,13 @@ func TestUnchangedFunc(t *testing.T) {
 	}
 	// test different tx
 	a1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x124", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x124", MiningStatus: "mined",
 		},
 	}
 	if unchanged(a1, b1) != false {
@@ -91,13 +91,13 @@ func TestUnchangedFunc(t *testing.T) {
 	}
 	// test identical statuses
 	a1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	b1 = map[common.ActivityID]common.ActivityStatus{
-		{1, "1"}: {
-			"done", "0x123", 0, "mined", nil,
+		{Timepoint: 1, EID: "1"}: {
+			ExchangeStatus: "done", Tx: "0x123", MiningStatus: "mined",
 		},
 	}
 	if unchanged(a1, b1) != true {

--- a/data/storage/bolt.go
+++ b/data/storage/bolt.go
@@ -250,8 +250,8 @@ func (self *BoltStorage) ExportExpiredAuthData(currentTime uint64, fileName stri
 				return err
 			}
 			record := common.AuthDataRecord{
-				common.Timestamp(strconv.FormatUint(timestamp, 10)),
-				temp,
+				Timestamp: common.Timestamp(strconv.FormatUint(timestamp, 10)),
+				Data:      temp,
 			}
 			var output []byte
 			output, err = json.Marshal(record)

--- a/data/storage/bolt_test.go
+++ b/data/storage/bolt_test.go
@@ -14,7 +14,7 @@ func TestHasPendingDepositBoltStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't init bolt storage %v", err)
 	}
-	token := common.Token{"OMG", "0x1111111111111111111111111111111111111111", 18}
+	token := common.Token{ID: "OMG", Address: "0x1111111111111111111111111111111111111111", Decimal: 18}
 	exchange := common.TestExchange{}
 	timepoint := common.GetTimepoint()
 	out, err := storage.HasPendingDeposit(token, exchange)
@@ -26,7 +26,7 @@ func TestHasPendingDepositBoltStorage(t *testing.T) {
 	}
 	storage.Record(
 		"deposit",
-		common.ActivityID{1, "1"},
+		common.ActivityID{Timepoint: 1, EID: "1"},
 		string(exchange.ID()),
 		map[string]interface{}{
 			"exchange":  exchange,

--- a/data/storage/ram_storage_test.go
+++ b/data/storage/ram_storage_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestHasPendingDepositRamStorage(t *testing.T) {
 	storage := NewRamStorage()
-	token := common.Token{"OMG", "0x1111111111111111111111111111111111111111", 18}
+	token := common.Token{ID: "OMG", Address: "0x1111111111111111111111111111111111111111", Decimal: 18}
 	exchange := common.TestExchange{}
 	timepoint := common.GetTimepoint()
 	out := storage.HasPendingDeposit(token, exchange)
@@ -17,7 +17,7 @@ func TestHasPendingDepositRamStorage(t *testing.T) {
 	}
 	storage.Record(
 		"deposit",
-		common.ActivityID{1, "1"},
+		common.ActivityID{Timepoint: 1, EID: "1"},
 		string(exchange.ID()),
 		map[string]interface{}{
 			"exchange":  exchange,

--- a/exchange/binance.go
+++ b/exchange/binance.go
@@ -221,8 +221,8 @@ func (self *Binance) FetchOnePairData(
 				result.Bids = append(
 					result.Bids,
 					common.PriceEntry{
-						quantity,
-						rate,
+						Quantity: quantity,
+						Rate:     rate,
 					},
 				)
 			}
@@ -232,8 +232,8 @@ func (self *Binance) FetchOnePairData(
 				result.Asks = append(
 					result.Asks,
 					common.PriceEntry{
-						quantity,
-						rate,
+						Quantity: quantity,
+						Rate:     rate,
 					},
 				)
 			}
@@ -392,11 +392,11 @@ func (self *Binance) FetchOnePairTradeHistory(
 			historyType = "buy"
 		}
 		tradeHistory := common.TradeHistory{
-			strconv.FormatUint(trade.ID, 10),
-			price,
-			quantity,
-			historyType,
-			trade.Time,
+			ID:        strconv.FormatUint(trade.ID, 10),
+			Price:     price,
+			Qty:       quantity,
+			Type:      historyType,
+			Timestamp: trade.Time,
 		}
 		result = append(result, tradeHistory)
 	}

--- a/exchange/bitfinex/bitfinex_endpoint.go
+++ b/exchange/bitfinex/bitfinex_endpoint.go
@@ -13,12 +13,12 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/KyberNetwork/reserve-data/common"
 	"github.com/KyberNetwork/reserve-data/exchange"
 	ethereum "github.com/ethereum/go-ethereum/common"
-	"sync"
 )
 
 type BitfinexEndpoint struct {
@@ -99,8 +99,8 @@ func (self *BitfinexEndpoint) FetchOnePairData(
 					result.Bids = append(
 						result.Bids,
 						common.PriceEntry{
-							quantity,
-							rate,
+							Quantity: quantity,
+							Rate:     rate,
 						},
 					)
 				}
@@ -110,8 +110,8 @@ func (self *BitfinexEndpoint) FetchOnePairData(
 					result.Asks = append(
 						result.Asks,
 						common.PriceEntry{
-							quantity,
-							rate,
+							Quantity: quantity,
+							Rate:     rate,
 						},
 					)
 				}

--- a/exchange/bittrex.go
+++ b/exchange/bittrex.go
@@ -282,8 +282,8 @@ func (self *Bittrex) FetchOnePairData(wq *sync.WaitGroup, pair common.TokenPair,
 				result.Bids = append(
 					result.Bids,
 					common.PriceEntry{
-						buy["Quantity"],
-						buy["Rate"],
+						Quantity: buy["Quantity"],
+						Rate:     buy["Rate"],
 					},
 				)
 			}
@@ -291,8 +291,8 @@ func (self *Bittrex) FetchOnePairData(wq *sync.WaitGroup, pair common.TokenPair,
 				result.Asks = append(
 					result.Asks,
 					common.PriceEntry{
-						sell["Quantity"],
-						sell["Rate"],
+						Quantity: sell["Quantity"],
+						Rate:     sell["Rate"],
 					},
 				)
 			}
@@ -377,11 +377,11 @@ func (self *Bittrex) FetchOnePairTradeHistory(
 			historyType = "buy"
 		}
 		tradeHistory := common.TradeHistory{
-			trade.OrderUuid,
-			trade.Price,
-			trade.Quantity,
-			historyType,
-			common.TimeToTimepoint(t),
+			ID:        trade.OrderUuid,
+			Price:     trade.Price,
+			Qty:       trade.Quantity,
+			Type:      historyType,
+			Timestamp: common.TimeToTimepoint(t),
 		}
 		result = append(result, tradeHistory)
 	}

--- a/exchange/bittrex_test.go
+++ b/exchange/bittrex_test.go
@@ -88,8 +88,8 @@ func getTestBittrex(depositHistory string, registered bool) *Bittrex {
 
 func TestDepositStatusNotFound(t *testing.T) {
 	activityID := common.ActivityID{
-		1513328774800747341,
-		"0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
+		Timepoint: 1513328774800747341,
+		EID:       "0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
 	}
 	bitt := getTestBittrex(
 		`{"success":true,"message":"","result":[{"Id":46291182,"Amount":15.89963814,"Currency":"OMG","Confirmations":39,"LastUpdated":"2017-12-14T18:51:55.32","TxId":"0xb5273548bb8d3d33ac685c5797cdeb11490178bda9d8f7c9b6d2740eca18771f","CryptoAddress":"0x9db6e8d2d133448dbcf755f19d540253da4ba043"},{"Id":46191533,"Amount":25.00000000,"Currency":"OMG","Confirmations":53,"LastUpdated":"2017-12-14T10:14:53.19","TxId":"0x32fae94e542b36a409c0d602e342743f8bcda3d1e1e1e26022abe050cfaf80a6","CryptoAddress":"0x9db6e8d2d133448dbcf755f19d540253da4ba043"},{"Id":46150485,"Amount":0.31000000,"Currency":"OMG","Confirmations":42,"LastUpdated":"2017-12-14T06:28:08.83","TxId":"0x8a345f58910b99843e3ccd852f15cbb2601d455f39038de2dc08589e7c39e0a8","CryptoAddress":"0x9db6e8d2d133448dbcf755f19d540253da4ba043"}]}`,
@@ -107,8 +107,8 @@ func TestDepositStatusNotFound(t *testing.T) {
 
 func TestDepositStatus(t *testing.T) {
 	activityID := common.ActivityID{
-		1513328774800747341,
-		"0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
+		Timepoint: 1513328774800747341,
+		EID:       "0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
 	}
 	bitt := getTestBittrex(
 		`{"success":true,"message":"","result":[{"Id":46452872,"Amount":5.00000000,"Currency":"OMG","Confirmations":42,"LastUpdated":"2017-12-15T09:27:09.597","TxId":"0x15ccaab008f161efeee0febc3e32242846cea1fc93995e5abc6fb88d94ae7d21","CryptoAddress":"0x9db6e8d2d133448dbcf755f19d540253da4ba043"}]}`,
@@ -126,8 +126,8 @@ func TestDepositStatus(t *testing.T) {
 
 func TestDepositStatusIgnoreRegisteredHistory(t *testing.T) {
 	activityID := common.ActivityID{
-		1513328774800747341,
-		"0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
+		Timepoint: 1513328774800747341,
+		EID:       "0x4e3c6c5e5c56ef2f65867e0dac874f3e2ec2f66e05793b7a52281549c02e68d9|OMG|5",
 	}
 	bitt := getTestBittrex(
 		`{"success":true,"message":"","result":[{"Id":46452872,"Amount":5.00000000,"Currency":"OMG","Confirmations":42,"LastUpdated":"2017-12-15T09:27:09.597","TxId":"0x15ccaab008f161efeee0febc3e32242846cea1fc93995e5abc6fb88d94ae7d21","CryptoAddress":"0x9db6e8d2d133448dbcf755f19d540253da4ba043"}]}`,

--- a/exchange/liqui.go
+++ b/exchange/liqui.go
@@ -180,8 +180,8 @@ func (self *Liqui) FetchPriceData(timepoint uint64) (map[common.TokenPairID]comm
 				one_pair_result.Bids = append(
 					one_pair_result.Bids,
 					common.PriceEntry{
-						buy[1],
-						buy[0],
+						Quantity: buy[1],
+						Rate:     buy[0],
 					},
 				)
 			}
@@ -189,8 +189,8 @@ func (self *Liqui) FetchPriceData(timepoint uint64) (map[common.TokenPairID]comm
 				one_pair_result.Asks = append(
 					one_pair_result.Asks,
 					common.PriceEntry{
-						sell[1],
-						sell[0],
+						Quantity: sell[1],
+						Rate:     sell[0],
 					},
 				)
 			}

--- a/exchange/util.go
+++ b/exchange/util.go
@@ -15,10 +15,10 @@ func getExchangePairsAndFeesFromConfig(
 	tokens := []common.Token{}
 	pairs := []common.TokenPair{}
 	fees := common.ExchangeFees{
-		feeConfig.Trading,
-		common.FundingFee{
-			map[string]float64{},
-			map[string]float64{},
+		Trading: feeConfig.Trading,
+		Funding: common.FundingFee{
+			Withdraw: map[string]float64{},
+			Deposit:  map[string]float64{},
 		},
 	}
 	minDeposit := common.ExchangesMinDeposit{}

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,0 +1,5 @@
+{
+    "Vendor": true,
+    "Errors": true,
+    "Deadline": "5m"
+}

--- a/stat/stat_storage_test_fw.go
+++ b/stat/stat_storage_test_fw.go
@@ -28,15 +28,13 @@ func NewStatStorageTest(storage StatStorage) *StatStorageTest {
 func (self *StatStorageTest) TestTradeStatsSummary() error {
 	var err error
 	mtStat := common.MetricStats{
-		10.0,
-		4567.8,
-		11.1,
-		3,
-		2,
-		4,
-		5,
-		0,
-		0,
+		ETHVolume:          10.0,
+		USDVolume:          4567.8,
+		BurnFee:            11.1,
+		TradeCount:         3,
+		UniqueAddr:         2,
+		KYCEd:              4,
+		NewUniqueAddresses: 5,
 	}
 	tzmtStat := common.MetricStatsTimeZone{0: {0: mtStat}}
 	updates := map[string]common.MetricStatsTimeZone{"trade_summary": tzmtStat}
@@ -69,15 +67,13 @@ func (self *StatStorageTest) TestWalletStats() error {
 	var err error
 
 	mtStat := common.MetricStats{
-		10.0,
-		4567.8,
-		11.1,
-		3,
-		2,
-		4,
-		5,
-		0,
-		0,
+		ETHVolume:          10.0,
+		USDVolume:          4567.8,
+		BurnFee:            11.1,
+		TradeCount:         3,
+		UniqueAddr:         2,
+		KYCEd:              4,
+		NewUniqueAddresses: 5,
 	}
 	testWallet := ethereum.HexToAddress(TESTASSETADDR)
 
@@ -125,15 +121,13 @@ func (self *StatStorageTest) TestWalletStats() error {
 func (self *StatStorageTest) TestCountryStats() error {
 	var err error
 	mtStat := common.MetricStats{
-		10.0,
-		4567.8,
-		11.1,
-		3,
-		2,
-		4,
-		5,
-		0,
-		0,
+		ETHVolume:          10.0,
+		USDVolume:          4567.8,
+		BurnFee:            11.1,
+		TradeCount:         3,
+		UniqueAddr:         2,
+		KYCEd:              4,
+		NewUniqueAddresses: 5,
 	}
 	tzmtStat := common.MetricStatsTimeZone{0: {0: mtStat}}
 	updates := map[string]common.MetricStatsTimeZone{TESTCOUNTRY: tzmtStat}
@@ -179,9 +173,9 @@ func (self *StatStorageTest) TestCountryStats() error {
 func (self *StatStorageTest) TestVolumeStats() error {
 	var err error
 	vlStat := common.VolumeStats{
-		10.0,
-		4567.8,
-		11.1,
+		ETHVolume: 10.0,
+		USDAmount: 4567.8,
+		Volume:    11.1,
 	}
 	testAsset := ethereum.HexToAddress(TESTASSETADDR)
 
@@ -273,7 +267,7 @@ func (self *StatStorageTest) TestVolumeStats() error {
 func (self *StatStorageTest) TestBurnFee() error {
 	var err error
 	bfStat := common.BurnFeeStats{
-		4567.8,
+		TotalBurnFee: 4567.8,
 	}
 
 	tzbfStat := common.BurnFeeStatsTimeZone{"D": {0: bfStat}}

--- a/stat/storage/analytic_bolt.go
+++ b/stat/storage/analytic_bolt.go
@@ -76,8 +76,8 @@ func (self *BoltAnalyticStorage) ExportExpiredPriceAnalyticData(currentTime uint
 				return err
 			}
 			record := common.AnalyticPriceResponse{
-				timestamp,
-				temp,
+				Timestamp: timestamp,
+				Data:      temp,
 			}
 			var output []byte
 			output, err = json.Marshal(record)


### PR DESCRIPTION
https://api.travis-ci.org/v3/job/380030134/log.txt

```
blockchain/blockchain.go:360::error: github.com/KyberNetwork/reserve-data/common.RateEntry composite literal uses unkeyed fields (vet)
blockchain/blockchain.go:429::error: github.com/KyberNetwork/reserve-data/vendor/github.com/ethereum/go-ethereum.FilterQuery composite literal uses unkeyed fields (vet)
cmd/clicmd/startserver.go:98::error: Panic call has possible formatting directive %s (vet)
cmd/clicmd/startserver_functions.go:106::error: Panic call has possible formatting directive %s (vet)
cmd/configuration/getconfig.go:87::error: github.com/KyberNetwork/reserve-data/common.Token composite literal uses unkeyed fields (vet)
core/reserve_core_test.go:139::error: github.com/KyberNetwork/reserve-data/common.Token composite literal uses unkeyed fields (vet)
core/reserve_core_test.go:148::error: github.com/KyberNetwork/reserve-data/common.Token composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:230::error: github.com/KyberNetwork/reserve-data/common.AllTradeHistory composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:339::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:350::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:358::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:369::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher.go:560::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:21::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:21::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:26::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:26::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:29::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:29::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:38::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:38::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:43::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:43::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:52::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:52::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:57::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:57::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:66::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:66::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:71::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:71::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:80::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:80::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:85::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:85::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:94::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:94::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:99::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/fetcher/fetcher_test.go:99::error: github.com/KyberNetwork/reserve-data/common.ActivityStatus composite literal uses unkeyed fields (vet)
data/storage/bolt.go:252::error: github.com/KyberNetwork/reserve-data/common.AuthDataRecord composite literal uses unkeyed fields (vet)
data/storage/bolt_test.go:17::error: github.com/KyberNetwork/reserve-data/common.Token composite literal uses unkeyed fields (vet)
data/storage/bolt_test.go:29::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
data/storage/ram_storage_test.go:11::error: github.com/KyberNetwork/reserve-data/common.Token composite literal uses unkeyed fields (vet)
data/storage/ram_storage_test.go:20::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
exchange/binance.go:123::error: return copies lock value: github.com/KyberNetwork/reserve-data/common.ExchangeInfo contains sync.RWMutex (vet)
exchange/binance.go:223::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/binance.go:234::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/binance.go:394::error: github.com/KyberNetwork/reserve-data/common.TradeHistory composite literal uses unkeyed fields (vet)
exchange/bittrex.go:91::error: return copies lock value: github.com/KyberNetwork/reserve-data/common.ExchangeInfo contains sync.RWMutex (vet)
exchange/bittrex.go:284::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/bittrex.go:293::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/bittrex.go:379::error: github.com/KyberNetwork/reserve-data/common.TradeHistory composite literal uses unkeyed fields (vet)
exchange/huobi.go:95::error: return copies lock value: github.com/KyberNetwork/reserve-data/common.ExchangeInfo contains sync.RWMutex (vet)
exchange/huobi.go:202::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:213::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:338::error: github.com/KyberNetwork/reserve-data/common.TradeHistory composite literal uses unkeyed fields (vet)
exchange/huobi.go:469::error: github.com/KyberNetwork/reserve-data/common.TXEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:487::error: github.com/KyberNetwork/reserve-data/common.TXEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:503::error: github.com/KyberNetwork/reserve-data/common.TXEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:525::error: github.com/KyberNetwork/reserve-data/common.TXEntry composite literal uses unkeyed fields (vet)
exchange/huobi.go:531::error: github.com/KyberNetwork/reserve-data/common.TXEntry composite literal uses unkeyed fields (vet)
exchange/liqui.go:182::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/liqui.go:191::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/stable_ex.go:45::error: return copies lock value: github.com/KyberNetwork/reserve-data/common.ExchangeInfo contains sync.RWMutex (vet)
exchange/util.go:17::error: github.com/KyberNetwork/reserve-data/common.ExchangeFees composite literal uses unkeyed fields (vet)
exchange/util.go:19::error: github.com/KyberNetwork/reserve-data/common.FundingFee composite literal uses unkeyed fields (vet)
exchange/bittrex_test.go:90::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
exchange/bittrex_test.go:109::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
exchange/bittrex_test.go:128::error: github.com/KyberNetwork/reserve-data/common.ActivityID composite literal uses unkeyed fields (vet)
exchange/bitfinex/bitfinex_endpoint.go:101::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
exchange/bitfinex/bitfinex_endpoint.go:112::error: github.com/KyberNetwork/reserve-data/common.PriceEntry composite literal uses unkeyed fields (vet)
stat/stat_storage_test_fw.go:30::error: github.com/KyberNetwork/reserve-data/common.MetricStats composite literal uses unkeyed fields (vet)
stat/stat_storage_test_fw.go:107::error: unreachable code (vet)
stat/stat_storage_test_fw.go:71::error: github.com/KyberNetwork/reserve-data/common.MetricStats composite literal uses unkeyed fields (vet)
stat/stat_storage_test_fw.go:127::error: github.com/KyberNetwork/reserve-data/common.MetricStats composite literal uses unkeyed fields (vet)
stat/stat_storage_test_fw.go:181::error: github.com/KyberNetwork/reserve-data/common.VolumeStats composite literal uses unkeyed fields (vet)
stat/stat_storage_test_fw.go:275::error: github.com/KyberNetwork/reserve-data/common.BurnFeeStats composite literal uses unkeyed fields (vet)
stat/storage/analytic_bolt.go:78::error: github.com/KyberNetwork/reserve-data/common.AnalyticPriceResponse composite literal uses unkeyed fields (vet)
```