### PR TITLE
update from id for binance trade history

### DIFF
--- a/exchange/binance/binance_endpoint.go
+++ b/exchange/binance/binance_endpoint.go
@@ -195,6 +195,8 @@ func (self *BinanceEndpoint) GetAccountTradeHistory(
 	}
 	if fromID != "" {
 		params["fromId"] = fromID
+	} else {
+		params["fromId"] = "0"
 	}
 	resp_body, err := self.GetResponse(
 		"GET",


### PR DESCRIPTION
I have misreading the binance API, if not provide fromId params, binance api will return most recent records, instead of return from 0.

I changed it, set default to 0. It should run correctly now.