### PR TITLE
Fix init binance

### DIFF
--- a/cmd/configuration/exchanges.go
+++ b/cmd/configuration/exchanges.go
@@ -94,7 +94,7 @@ func NewExchangePool(
 		case "binance":
 			binanceSigner := binance.NewSignerFromFile(settingPaths.secretPath)
 			endpoint := binance.NewBinanceEndpoint(binanceSigner, getBinanceInterface(kyberENV))
-			storage, err := huobi.NewBoltStorage(filepath.Join(common.CmdDirLocation(), "binance.db"))
+			storage, err := binance.NewBoltStorage(filepath.Join(common.CmdDirLocation(), "binance.db"))
 			if err != nil {
 				log.Panic(err)
 			}

--- a/exchange/binance/binance_bolt.go
+++ b/exchange/binance/binance_bolt.go
@@ -3,7 +3,6 @@ package binance
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -82,7 +81,7 @@ func (self *BinanceStorage) GetTradeHistory(fromTime, toTime uint64) (common.Exc
 	result := common.ExchangeTradeHistory{}
 	var err error
 	if toTime-fromTime > MAX_GET_TRADE_HISTORY {
-		return result, fmt.Errorf("Time range is too broad, it must be smaller or equal to 3 days (miliseconds)"))
+		return result, fmt.Errorf("Time range is too broad, it must be smaller or equal to 3 days (miliseconds)")
 	}
 	min := []byte(strconv.FormatUint(fromTime, 10))
 	max := []byte(strconv.FormatUint(toTime, 10))

--- a/exchange/binance/binance_bolt.go
+++ b/exchange/binance/binance_bolt.go
@@ -23,7 +23,7 @@ type BinanceStorage struct {
 	db *bolt.DB
 }
 
-func NewBoltExchangeStorage(path string) (*BinanceStorage, error) {
+func NewBoltStorage(path string) (*BinanceStorage, error) {
 	// init instance
 	var err error
 	var db *bolt.DB
@@ -82,7 +82,7 @@ func (self *BinanceStorage) GetTradeHistory(fromTime, toTime uint64) (common.Exc
 	result := common.ExchangeTradeHistory{}
 	var err error
 	if toTime-fromTime > MAX_GET_TRADE_HISTORY {
-		return result, errors.New(fmt.Sprintf("Time range is too broad, it must be smaller or equal to 3 days (miliseconds)"))
+		return result, fmt.Errorf("Time range is too broad, it must be smaller or equal to 3 days (miliseconds)"))
 	}
 	min := []byte(strconv.FormatUint(fromTime, 10))
 	max := []byte(strconv.FormatUint(toTime, 10))


### PR DESCRIPTION
Currently, binance is running with storage init by huobi: https://github.com/KyberNetwork/reserve-data/blob/4c4507869ac82502f1889bb834a1f87404cf71b9/cmd/configuration/exchanges.go#L97

which should be changed to use binance storage.