### PR TITLE
add sort before storing logs

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -617,6 +617,21 @@ type KNLog interface {
 	Type() string
 }
 
+// ByBLock type is used to sort KNlog in increasing order of block number
+type ByBlock []KNLog
+
+func (b ByBlock) Len() int {
+	return len(b)
+}
+
+func (b ByBlock) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b ByBlock) Less(i, j int) bool {
+	return b[i].BlockNo() < b[j].BlockNo()
+}
+
 type SetCatLog struct {
 	Timestamp       uint64
 	BlockNumber     uint64

--- a/stat/fetcher.go
+++ b/stat/fetcher.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -861,6 +862,7 @@ func (self *Fetcher) FetchLogs(fromBlock uint64, toBlock uint64, timepoint uint6
 		return enforceFromBlock(fromBlock), err
 	}
 	if len(logs) > 0 {
+		sort.Sort(common.ByBlock(logs))
 		var maxBlock = enforceFromBlock(fromBlock)
 		for _, il := range logs {
 			// If there is log conversion error, print error and continue to the next log


### PR DESCRIPTION
To fix the potential skipping logs if store log fail, the logs must be sorted in increasing order of blockNumber before processing