### PR TITLE
Add cancel all order api

### DIFF
--- a/gateway/http/permission.go
+++ b/gateway/http/permission.go
@@ -48,6 +48,7 @@ func addKeyRebalancePolicy(key string) string {
 p, %[1]s, /*, GET
 p, %[1]s, /v3/price-factor, POST
 p, %[1]s, /v3/cancelorder, POST
+p, %[1]s, /v3/cancel-all-orders, POST
 p, %[1]s, /v3/deposit, POST
 p, %[1]s, /v3/withdraw, POST
 p, %[1]s, /v3/trade, POST

--- a/gateway/http/routes_proxy.go
+++ b/gateway/http/routes_proxy.go
@@ -24,6 +24,7 @@ func WithCoreEndpoint(coreEndpoint string) Option {
 		g.GET("/immediate-pending-activities", coreProxyMW)
 
 		g.POST("/cancelorder", coreProxyMW)
+		g.POST("/cancel-all-orders", coreProxyMW)
 		g.POST("/deposit", coreProxyMW)
 		g.POST("/withdraw", coreProxyMW)
 		g.POST("/trade", coreProxyMW)

--- a/http/exchange_api.go
+++ b/http/exchange_api.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/KyberNetwork/reserve-data/common"
+	"github.com/KyberNetwork/reserve-data/http/httputil"
+)
+
+// CancelAllOrders cancel all orders
+func (s *Server) CancelAllOrders(c *gin.Context) {
+	pendingActivites, err := s.app.GetPendingActivities()
+	if err != nil {
+		httputil.ResponseFailure(c, httputil.WithError(err))
+		return
+	}
+
+	for _, activity := range pendingActivites {
+		if activity.Action == common.ActionTrade {
+			exchange := activity.Params["exchange"].(common.Exchange)
+			// Cancel order
+			if err := s.core.CancelOrder(activity.ID, exchange); err != nil {
+				httputil.ResponseFailure(c, httputil.WithError(err))
+				return
+			}
+		}
+	}
+
+	httputil.ResponseSuccess(c)
+}

--- a/http/server.go
+++ b/http/server.go
@@ -421,7 +421,7 @@ func (s *Server) register() {
 		g.GET("/immediate-pending-activities", s.ImmediatePendingActivities)
 
 		g.POST("/cancelorder", s.CancelOrder)
-		g.POST("/cancel-all-order", s.CancelAllOrders)
+		g.POST("/cancel-all-orders", s.CancelAllOrders)
 		g.POST("/deposit", s.Deposit)
 		g.POST("/withdraw", s.Withdraw)
 		g.POST("/trade", s.Trade)

--- a/http/server.go
+++ b/http/server.go
@@ -421,6 +421,7 @@ func (s *Server) register() {
 		g.GET("/immediate-pending-activities", s.ImmediatePendingActivities)
 
 		g.POST("/cancelorder", s.CancelOrder)
+		g.POST("/cancel-all-order", s.CancelAllOrders)
 		g.POST("/deposit", s.Deposit)
 		g.POST("/withdraw", s.Withdraw)
 		g.POST("/trade", s.Trade)


### PR DESCRIPTION
Always return success with form:

```json
{
    "success": true,
    "data": [
        {
            "id": 1,
            "reason": "binance key is invalid"
        }
    ]
}
```

if there is no failed cancel order then "data" will be empty.