### PR TITLE
update load and set tokens indices (#758)

### DIFF
--- a/blockchain/compact_rate.go
+++ b/blockchain/compact_rate.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"fmt"
 	"math/big"
 	"strconv"
 
@@ -53,14 +54,18 @@ type bulk struct {
 	data [14]byte
 }
 
-func BuildCompactBulk(newBuys, newSells map[ethereum.Address]byte, indices map[string]tbindex) ([][14]byte, [][14]byte, []*big.Int) {
+// BuildCompactBulk build bulk compact rate
+func BuildCompactBulk(newBuys, newSells map[ethereum.Address]byte, indices map[string]tbindex) ([][14]byte, [][14]byte, []*big.Int, error) {
 	buyResults := [][14]byte{}
 	sellResults := [][14]byte{}
 	indexResults := []*big.Int{}
 	buyBulks := map[uint64]*bulk{}
 	sellBulks := map[uint64]*bulk{}
 	for addr, buyCompact := range newBuys {
-		index := indices[addr.Hex()]
+		index, ok := indices[addr.Hex()]
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("cannot find token index, token: %s", addr.Hex())
+		}
 		_, exist := buyBulks[index.BulkIndex]
 		if !exist {
 			buyBulks[index.BulkIndex] = &bulk{}
@@ -76,5 +81,5 @@ func BuildCompactBulk(newBuys, newSells map[ethereum.Address]byte, indices map[s
 		sellResults = append(sellResults, sellBulks[index].data)
 		indexResults = append(indexResults, big.NewInt(int64(index)))
 	}
-	return buyResults, sellResults, indexResults
+	return buyResults, sellResults, indexResults, nil
 }

--- a/blockchain/compact_rate_test.go
+++ b/blockchain/compact_rate_test.go
@@ -119,7 +119,7 @@ func TestBuildCompactBulk(t *testing.T) {
 		addr2: newTBIndex(9, 5),
 		addr3: newTBIndex(9, 6),
 	}
-	buyBulk, sellBulk, indices := BuildCompactBulk(
+	buyBulk, sellBulk, indices, _ := BuildCompactBulk(
 		buysInput, sellsInput, indicesInput)
 	expectedBuys := [][14]byte{
 		{0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0},

--- a/cmd/clicmd/startserver_functions.go
+++ b/cmd/clicmd/startserver_functions.go
@@ -189,6 +189,7 @@ func GetConfigFromENV(kyberENV string) *configuration.Config {
 	return config
 }
 
+// CreateBlockchain create new blockchain instance
 func CreateBlockchain(config *configuration.Config) (bc *blockchain.Blockchain, err error) {
 	bc, err = blockchain.NewBlockchain(
 		config.Blockchain,
@@ -199,13 +200,8 @@ func CreateBlockchain(config *configuration.Config) (bc *blockchain.Blockchain, 
 		panic(err)
 	}
 
-	// old contract addresses are used for events fetcher
-
-	tokens, err := config.Setting.GetInternalTokens()
-	if err != nil {
-		log.Panicf("Can't get the list of Internal Tokens for indices: %s", err)
-	}
-	err = bc.LoadAndSetTokenIndices(common.GetTokenAddressesList(tokens))
+	// load all listed token indices instead of only configs tokens
+	err = bc.LoadAndSetTokenIndices()
 	if err != nil {
 		log.Panicf("Can't load and set token indices: %s", err)
 	}

--- a/core/reserve_core_test.go
+++ b/core/reserve_core_test.go
@@ -63,6 +63,12 @@ func (te testExchange) GetLiveExchangeInfos(pairIDs []common.TokenPairID) (commo
 type testBlockchain struct {
 }
 
+func (tbc testBlockchain) SetListedToken(listedTokens []ethereum.Address) {}
+
+func (tbc testBlockchain) ListedTokens() []ethereum.Address {
+	return nil
+}
+
 func (tbc testBlockchain) Send(
 	token common.Token,
 	amount *big.Int,

--- a/http/http_blockchain.go
+++ b/http/http_blockchain.go
@@ -7,10 +7,10 @@ import (
 // Blockchain is used in http server as the caller to blockchain for information.
 // Currently it is used for smart contract token's indice query.
 type Blockchain interface {
-	LoadAndSetTokenIndices([]ethereum.Address) error
+	LoadAndSetTokenIndices() error
 	CheckTokenIndices(ethereum.Address) error
 	GetPricingOPAddress() ethereum.Address
 	GetDepositOPAddress() ethereum.Address
 	GetIntermediatorOPAddress() ethereum.Address
-	GetListedTokens() ([]ethereum.Address, error)
+	ListedTokens() []ethereum.Address
 }

--- a/http/token_update_test.go
+++ b/http/token_update_test.go
@@ -445,6 +445,10 @@ func TestHTTPServerUpdateToken(t *testing.T) {
 
 type testHTTPBlockchain struct{}
 
+func (tbc testHTTPBlockchain) ListedTokens() []ethereum.Address {
+	return nil
+}
+
 func (tbc testHTTPBlockchain) CheckTokenIndices(addr ethereum.Address) error {
 	const correctAddrstr = "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07"
 	correctAddr := ethereum.HexToAddress(correctAddrstr)
@@ -454,7 +458,7 @@ func (tbc testHTTPBlockchain) CheckTokenIndices(addr ethereum.Address) error {
 	return errors.New("wrong address")
 }
 
-func (tbc testHTTPBlockchain) LoadAndSetTokenIndices(addrs []ethereum.Address) error {
+func (tbc testHTTPBlockchain) LoadAndSetTokenIndices() error {
 	return nil
 }
 
@@ -468,8 +472,4 @@ func (tbc testHTTPBlockchain) GetDepositOPAddress() ethereum.Address {
 
 func (tbc testHTTPBlockchain) GetIntermediatorOPAddress() ethereum.Address {
 	return ethereum.Address{}
-}
-
-func (tbc testHTTPBlockchain) GetListedTokens() ([]ethereum.Address, error) {
-	return nil, nil
 }


### PR DESCRIPTION
- tokenIndices will load from all token we have on blockchain instead of in core db
- check token index to be exists when build compact data for setRate
- listedToken and indices now load at start and reload when confirm update token setting.