### PR TITLE
adjust formular calculate new price for override setRate

### DIFF
--- a/core/activity_storage.go
+++ b/core/activity_storage.go
@@ -27,4 +27,6 @@ type ActivityStorage interface {
 	// PendingActivityForAction return the last pending set rate and number of pending
 	// transactions.
 	PendingActivityForAction(minedNonce uint64, activityType string) (*common.ActivityRecord, uint64, error)
+	// find
+	GetPendingSetRate(action string, minedNonce uint64) (*common.ActivityRecord, error)
 }

--- a/core/reserve_core_test.go
+++ b/core/reserve_core_test.go
@@ -131,6 +131,10 @@ type testActivityStorage struct {
 	PendingDeposit bool
 }
 
+func (tas testActivityStorage) GetPendingSetRate(action string, minedNonce uint64) (*common.ActivityRecord, error) {
+	panic("implement me")
+}
+
 func (tas testActivityStorage) MaxPendingNonce(action string) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
I propose a change the way we calculate new price for override nonce
details: 
current method: of we count number of pending tx and use as step increasing gasPrice [initPrice -> maxPrice]
new method: we stick with gasPrice from gas-service, but it should >10% compare to last recent pending price(so node won't complain about underprice, I guess)

this is because our maxPrice is pretty high now(1000 gwei), so current method can use unnecessary high price.