### PR TITLE
correct activity state on for failed tx

### DIFF
--- a/cmd/configuration/flags.go
+++ b/cmd/configuration/flags.go
@@ -136,14 +136,7 @@ func CreateDataCore(config *Config,
 	rcf common.RawConfig,
 	httpClient *http.Client) (*data.ReserveData, *core.ReserveCore, *gasinfo.GasPriceInfo) {
 	// get fetcher based on config and ENV == simulation.
-	dataFetcher := fetcher.NewFetcher(
-		config.FetcherStorage,
-		config.FetcherGlobalStorage,
-		config.World,
-		config.FetcherRunner,
-		dpl == deployment.Simulation,
-		config.ContractAddresses,
-	)
+	dataFetcher := fetcher.NewFetcher(config.FetcherStorage, config.FetcherGlobalStorage, config.World, config.FetcherRunner, dpl == deployment.Simulation, config.ContractAddresses)
 
 	for _, ex := range config.FetcherExchanges {
 		dataFetcher.AddExchange(ex)

--- a/cmd/migrations/000016_add_result_nonce_index.down.sql
+++ b/cmd/migrations/000016_add_result_nonce_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS activity_nonce_idx;

--- a/cmd/migrations/000016_add_result_nonce_index.up.sql
+++ b/cmd/migrations/000016_add_result_nonce_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX activity_nonce_idx ON activity(((data->'result'->'nonce')::int));

--- a/common/util.go
+++ b/common/util.go
@@ -124,3 +124,13 @@ func getFrame(skipFrames int) runtime.Frame {
 
 	return frame
 }
+
+func CalculateNewPrice(pendingPrice float64, recommendPrice float64) float64 {
+	switch {
+	// if recommendPrice less than pending price, choose pending price as we can't override tx if use smaller price.
+	case recommendPrice <= pendingPrice:
+		return pendingPrice + (pendingPrice * 0.1) // increase 10% to prevent node to decline (I'm not sure on this)
+	default:
+		return math.Max(recommendPrice, pendingPrice*1.1) // recommendPrice should > pendingPrice at least 10% gwei
+	}
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -32,5 +32,5 @@ type Blockchain interface {
 	BuildSendETHTx(opts blockchain.TxOpts, to ethereum.Address) (*types.Transaction, error)
 	GetDepositOPAddress() ethereum.Address
 	SignAndBroadcast(tx *types.Transaction, from string) (*types.Transaction, error)
-	SpeedupDeposit(tx ethereum.Hash, gasPrice *big.Int) (ethereum.Hash, error)
+	SpeedupDeposit(tx ethereum.Hash, recommendGasPrice float64, maxGasPrice float64) (*types.Transaction, error)
 }

--- a/core/reserve_core_test.go
+++ b/core/reserve_core_test.go
@@ -70,7 +70,7 @@ func (tbc testBlockchain) TransferToSelf(op string, gasPrice *big.Int, nonce *bi
 	panic("implement me")
 }
 
-func (tbc testBlockchain) SpeedupDeposit(tx ethereum.Hash, gasPrice *big.Int) (ethereum.Hash, error) {
+func (tbc testBlockchain) SpeedupDeposit(tx ethereum.Hash, recommendGasPrice float64, maxGasPrice float64) (*types.Transaction, error) {
 	panic("implement me")
 }
 

--- a/data/fetcher/storage.go
+++ b/data/fetcher/storage.go
@@ -15,4 +15,5 @@ type Storage interface {
 
 	CurrentAuthDataVersion(timepoint uint64) (common.Version, error)
 	GetAuthData(common.Version) (common.AuthDataSnapshot, error)
+	FindReplacedTx(action string, nonce uint64) (string, error)
 }

--- a/data/storage/postgres.go
+++ b/data/storage/postgres.go
@@ -612,7 +612,7 @@ SELECT data FROM pending WHERE (data->'result'->>'nonce')::int = (SELECT MIN((da
 func (ps *PostgresStorage) FindReplacedTx(action string, nonce uint64) (string, error) {
 	var tx string
 	err := ps.db.Get(&tx,
-		`SELECT data->'result'->>'tx' from activity where (data->'result'->>'nonce')=$1 AND data->>'action'=$2 AND data->>'mining_status'=$3`,
+		`SELECT data->'result'->>'tx' from activity where (data->'result'->>'nonce')::int=$1 AND data->>'action'=$2 AND data->>'mining_status'=$3`,
 		nonce, action, common.MiningStatusMined)
 	if err == sql.ErrNoRows {
 		return "", nil
@@ -650,7 +650,7 @@ func (ps *PostgresStorage) HasPendingDeposit(token commonv3.Asset, exchange comm
 // MaxPendingNonce return biggest nonce in pending activity for an action
 func (ps *PostgresStorage) MaxPendingNonce(action string) (int64, error) {
 	var v int64
-	if err := ps.db.Get(&v, "SELECT MAX(data->'result'->>'nonce') FROM activity WHERE is_pending IS TRUE AND data->>'action' = $1", action); err != nil {
+	if err := ps.db.Get(&v, "SELECT MAX((data->'result'->>'nonce')::int) FROM activity WHERE is_pending IS TRUE AND data->>'action' = $1", action); err != nil {
 		if err == sql.ErrNoRows {
 			return 0, nil
 		}


### PR DESCRIPTION
this MR addresses below issues:
- fix speedupDeposit does not always increase gasPrice, now it use same calculate function with override nonce for setRate
- override nonce activity now show error message as `replace by tx ...`
- extend monitor lost tx by 5 minutes, to make sure it actually lost, in mean time, if we found an other tx with same nonce and mined, it will help confirm replaced tx early.